### PR TITLE
feat(MemoryScrolls): 绘卷任务结束后跳转回主界面

### DIFF
--- a/tasks/MemoryScrolls/script_task.py
+++ b/tasks/MemoryScrolls/script_task.py
@@ -9,7 +9,7 @@ from module.base.timer import Timer
 from datetime import timedelta, datetime
 
 from tasks.GameUi.game_ui import GameUi
-from tasks.GameUi.page import page_summon
+from tasks.GameUi.page import page_summon, page_main
 from tasks.MemoryScrolls.assets import MemoryScrollsAssets
 from tasks.MemoryScrolls.config import ScrollNumber
 
@@ -20,7 +20,9 @@ class ScriptTask(GameUi, MemoryScrollsAssets):
         self.goto_page(page_summon)
         con = self.config.memory_scrolls.memory_scrolls_config
         # 进入绘卷主界面
-        self.goto_memoryscrolls_main(con) 
+        self.goto_memoryscrolls_main(con)
+        # 返回主界面
+        self.goto_page(page_main)
         raise TaskEnd
     
     def goto_memoryscrolls_main(self, con):


### PR DESCRIPTION
绘卷任务完成后停留在绘卷界面，导致后续探索任务启动时页面识别失败，60秒超时报 `GameStuckError`。此 PR 在绘卷结束后增加一步跳转回主界面，避免该问题。