### PR TITLE
适配 Redroid 容器登录流程

### DIFF
--- a/tasks/Component/Login/service.py
+++ b/tasks/Component/Login/service.py
@@ -26,13 +26,21 @@ class LoginService(BaseTask, RestartAssets, GameUiAssets):
         click_count = 0
 
         while not timeout_timer.reached():
+            self.screenshot()
+            if self.appear(self.I_LOGIN_8):
+                logger.info('Redroid login preparation: login screen already appeared')
+                return True
+
             if center_click_timer.reached():
                 self.device.click(x=640, y=360, control_name='REDROID_LOGIN_CENTER')
                 click_count += 1
                 logger.info(f'Redroid login preparation: clicked screen center (attempt {click_count})')
                 center_click_timer = Timer(3).start()
+                self.screenshot()
+                if self.appear(self.I_LOGIN_8):
+                    logger.info('Redroid login preparation: login screen appeared after center click')
+                    return True
 
-            self.screenshot()
             if self.ocr_appear(self.O_LOGIN_REDROID_SKIP):
                 self.click(self.O_LOGIN_REDROID_SKIP)
                 logger.info('Redroid login preparation: detected 跳过, clicked skip button')

--- a/tasks/Component/Login/service.py
+++ b/tasks/Component/Login/service.py
@@ -27,13 +27,23 @@ class LoginService(BaseTask, RestartAssets, GameUiAssets):
 
         confirm_timer = Timer(1.5, count=2).start()
         orientation_timer = Timer(10)
-        login_animation_timer = Timer(5).start()
-        login_animation_timeout_timer = Timer(30).start()
-        center_click_timer = Timer(0).start()
-        skip_click_timer = Timer(0).start()
+        login_animation = True
+        login_animation_timer = Timer(5)
+        login_animation_timeout_timer = Timer(30)
         center_click_count = 0
         login_animation_timeout_logged = False
         login_success = False
+
+        def reset_login_animation_timers():
+            if login_animation_timer.started():
+                login_animation_timer.reset()
+            if login_animation_timeout_timer.started():
+                login_animation_timeout_timer.reset()
+
+        def disable_login_animation():
+            nonlocal login_animation
+            login_animation = False
+            reset_login_animation_timers()
 
         while 1:
             if not login_success and orientation_timer.reached():
@@ -43,10 +53,12 @@ class LoginService(BaseTask, RestartAssets, GameUiAssets):
             self.screenshot()
             if self.appear_then_click(self.I_CANCEL_BATTLE, interval=0.8):
                 logger.info('Cancel continue battle')
+                disable_login_animation()
                 continue
             if self.appear(self.I_CHECK_MAIN, interval=0.2) and not self.appear(self.I_MAIN_GOTO_SHIKIGAMI_RECORDS):
                 logger.info('The main had already appeared, but shikigami records had not yet appeared')
                 if self.click(self.C_LOGIN_SCROLL_CLOSE_AREA, interval=2):
+                    disable_login_animation()
                     continue
             if self.appear(self.I_MAIN_GOTO_SHIKIGAMI_RECORDS, interval=0.2):
                 if confirm_timer.reached():
@@ -62,21 +74,27 @@ class LoginService(BaseTask, RestartAssets, GameUiAssets):
                 self.I_HARVEST_ZIDU.roi_front[1] -= 200
                 if self.click(self.I_HARVEST_ZIDU, interval=2):
                     logger.info('Close zidu')
+                    disable_login_animation()
                 continue
             if self.appear_then_click(self.I_UI_CONFIRM_SAMLL, interval=2.5):
                 logger.info('Soul overflow confirm')
+                disable_login_animation()
                 continue
             if self.appear_then_click(self.I_LOGIN_LOAD_DOWN, interval=1):
                 logger.info('Download inbetweening')
+                disable_login_animation()
                 continue
             if self.appear_then_click(self.I_WATCH_VIDEO_CANCEL, interval=0.6):
                 logger.info('Close video')
+                disable_login_animation()
                 continue
             if self.appear_then_click(self.I_LOGIN_RED_CLOSE, interval=0.6):
                 logger.info('Close red close')
+                disable_login_animation()
                 continue
             if self.appear_then_click(self.I_LOGIN_YELLOW_CLOSE, interval=0.6):
                 logger.info('Close yellow close')
+                disable_login_animation()
                 continue
             if self.appear_then_click(self.I_LOGIN_LOGIN_GOTO_BIND_PHONE):
                 while 1:
@@ -84,13 +102,16 @@ class LoginService(BaseTask, RestartAssets, GameUiAssets):
                     if self.appear_then_click(self.I_LOGIN_LOGIN_CANCEL_BIND_PHONE):
                         logger.info("Close bind phone")
                         break
+                disable_login_animation()
                 continue
             from tasks.Component.GeneralInvite.assets import GeneralInviteAssets as gia
             if self.appear_then_click(gia.I_I_REJECT, interval=0.8):
                 logger.info("reject invites")
+                disable_login_animation()
                 continue
             if self.appear_then_click(self.I_LOGIN_LOGIN_ONMYOJI_GENIE):
                 logger.info("click onmyoji genie")
+                disable_login_animation()
                 continue
             if self.appear(self.I_LOGIN_SPECIFIC_SERVE, interval=0.6) \
                     and self.ocr_appear_click(self.O_LOGIN_SPECIFIC_SERVE, interval=0.6):
@@ -101,6 +122,7 @@ class LoginService(BaseTask, RestartAssets, GameUiAssets):
                         continue
                     break
                 logger.info('login specific user')
+                disable_login_animation()
                 continue
 
             if self.appear(self.I_CREATE_ACCOUNT):
@@ -110,49 +132,41 @@ class LoginService(BaseTask, RestartAssets, GameUiAssets):
             if self.appear(self.I_CHARACTARS, interval=1):
                 logger.info('误入区服设置')
                 self.device.click(x=106, y=535)
+                disable_login_animation()
 
-            if not self.appear(self.I_LOGIN_8):
-                if self.ocr_appear(self.O_LOGIN_ENTER_GAME):
-                    x, y = self.O_LOGIN_ENTER_GAME.coord()
-                    self.device.click(x=x, y=y, control_name=self.O_LOGIN_ENTER_GAME.name)
-                    logger.info('Login: detected 进入游戏, clicked enter game')
-                    self.wait_until_appear(self.I_LOGIN_SPECIFIC_SERVE, True, wait_time=5)
-                    continue
-
-                if not login_animation_timer.reached():
-                    continue
-
+            login_screen_appeared = self.appear(self.I_LOGIN_8)
+            if login_animation and not login_screen_appeared:
+                if not login_animation_timer.started():
+                    login_animation_timer.start()
+                if not login_animation_timeout_timer.started():
+                    login_animation_timeout_timer.start()
                 if login_animation_timeout_timer.reached():
                     if not login_animation_timeout_logged:
                         logger.warning('Login animation: fallback timeout, continue with normal login flow')
                         login_animation_timeout_logged = True
                     continue
-
-                if center_click_timer.reached():
-                    self.device.click(x=640, y=360, control_name='LOGIN_ANIMATION_CENTER')
+                if not login_animation_timer.reached():
+                    continue
+                if self.click(self.C_LOGIN_ANIMATION_CENTER, interval=3):
                     center_click_count += 1
                     logger.info(f'Login animation: clicked center area (attempt {center_click_count})')
-                    center_click_timer = Timer(3).start()
-                    self.screenshot()
-
-                if skip_click_timer.reached() and self.ocr_appear(self.O_LOGIN_ANIMATION_SKIP):
-                    x, y = self.O_LOGIN_ANIMATION_SKIP.coord()
-                    self.device.click(x=x, y=y, control_name=self.O_LOGIN_ANIMATION_SKIP.name)
+                    continue
+                if self.ocr_appear_click(self.O_LOGIN_ANIMATION_SKIP, interval=1):
                     logger.info('Login animation: detected 跳过, clicked skip button')
-                    skip_click_timer = Timer(1).start()
+                continue
 
-                    self.screenshot()
-                    if self.appear(self.I_LOGIN_8) or not self.ocr_appear(self.O_LOGIN_ANIMATION_SKIP):
-                        logger.info('Login animation: skip click confirmed')
-                    else:
-                        logger.warning('Login animation: skip click not confirmed, retrying')
+            if login_animation and login_screen_appeared:
+                disable_login_animation()
+            if not login_screen_appeared:
                 continue
 
             if self.appear(self.I_EARLY_SERVER):
                 if self.appear_then_click(self.I_EARLY_SERVER_CANCEL):
                     logger.info('Cancel switch from early server to normal server')
+                    disable_login_animation()
                     continue
             if self.ocr_appear_click(self.O_LOGIN_ENTER_GAME, interval=3):
+                disable_login_animation()
                 self.wait_until_appear(self.I_LOGIN_SPECIFIC_SERVE, True, wait_time=5)
                 continue
 

--- a/tasks/Component/Login/service.py
+++ b/tasks/Component/Login/service.py
@@ -17,6 +17,32 @@ class LoginService(BaseTask, RestartAssets, GameUiAssets):
         self.character = self.config.restart.login_character_config.character
         self.O_LOGIN_SPECIFIC_SERVE.keyword = self.character
 
+    def prepare_redroid_login(self) -> bool:
+        """触发 Redroid 视频页的跳过按钮并点击。"""
+        logger.hr('Redroid login preparation')
+        self.device.sleep(3)
+        timeout_timer = Timer(30).start()
+        center_click_timer = Timer(0).start()
+        click_count = 0
+
+        while not timeout_timer.reached():
+            if center_click_timer.reached():
+                self.device.click(x=640, y=360, control_name='REDROID_LOGIN_CENTER')
+                click_count += 1
+                logger.info(f'Redroid login preparation: clicked screen center (attempt {click_count})')
+                center_click_timer = Timer(3).start()
+
+            self.screenshot()
+            if self.ocr_appear(self.O_LOGIN_REDROID_SKIP):
+                self.click(self.O_LOGIN_REDROID_SKIP)
+                logger.info('Redroid login preparation: detected 跳过, clicked skip button')
+                return True
+
+            self.device.sleep(0.5)
+
+        logger.warning('Redroid login preparation: skip button not detected')
+        return False
+
     def _app_handle_login(self) -> bool:
         """
         最终是在庭院界面

--- a/tasks/Component/Login/service.py
+++ b/tasks/Component/Login/service.py
@@ -17,40 +17,6 @@ class LoginService(BaseTask, RestartAssets, GameUiAssets):
         self.character = self.config.restart.login_character_config.character
         self.O_LOGIN_SPECIFIC_SERVE.keyword = self.character
 
-    def prepare_redroid_login(self) -> bool:
-        """触发 Redroid 视频页的跳过按钮并点击。"""
-        logger.hr('Redroid login preparation')
-        self.device.sleep(3)
-        timeout_timer = Timer(30).start()
-        center_click_timer = Timer(0).start()
-        click_count = 0
-
-        while not timeout_timer.reached():
-            self.screenshot()
-            if self.appear(self.I_LOGIN_8):
-                logger.info('Redroid login preparation: login screen already appeared')
-                return True
-
-            if center_click_timer.reached():
-                self.device.click(x=640, y=360, control_name='REDROID_LOGIN_CENTER')
-                click_count += 1
-                logger.info(f'Redroid login preparation: clicked screen center (attempt {click_count})')
-                center_click_timer = Timer(3).start()
-                self.screenshot()
-                if self.appear(self.I_LOGIN_8):
-                    logger.info('Redroid login preparation: login screen appeared after center click')
-                    return True
-
-            if self.ocr_appear(self.O_LOGIN_REDROID_SKIP):
-                self.click(self.O_LOGIN_REDROID_SKIP)
-                logger.info('Redroid login preparation: detected 跳过, clicked skip button')
-                return True
-
-            self.device.sleep(0.5)
-
-        logger.warning('Redroid login preparation: skip button not detected')
-        return False
-
     def _app_handle_login(self) -> bool:
         """
         最终是在庭院界面
@@ -61,6 +27,12 @@ class LoginService(BaseTask, RestartAssets, GameUiAssets):
 
         confirm_timer = Timer(1.5, count=2).start()
         orientation_timer = Timer(10)
+        login_animation_timer = Timer(5).start()
+        login_animation_timeout_timer = Timer(30).start()
+        center_click_timer = Timer(0).start()
+        skip_click_timer = Timer(0).start()
+        center_click_count = 0
+        login_animation_timeout_logged = False
         login_success = False
 
         while 1:
@@ -140,6 +112,40 @@ class LoginService(BaseTask, RestartAssets, GameUiAssets):
                 self.device.click(x=106, y=535)
 
             if not self.appear(self.I_LOGIN_8):
+                if self.ocr_appear(self.O_LOGIN_ENTER_GAME):
+                    x, y = self.O_LOGIN_ENTER_GAME.coord()
+                    self.device.click(x=x, y=y, control_name=self.O_LOGIN_ENTER_GAME.name)
+                    logger.info('Login: detected 进入游戏, clicked enter game')
+                    self.wait_until_appear(self.I_LOGIN_SPECIFIC_SERVE, True, wait_time=5)
+                    continue
+
+                if not login_animation_timer.reached():
+                    continue
+
+                if login_animation_timeout_timer.reached():
+                    if not login_animation_timeout_logged:
+                        logger.warning('Login animation: fallback timeout, continue with normal login flow')
+                        login_animation_timeout_logged = True
+                    continue
+
+                if center_click_timer.reached():
+                    self.device.click(x=640, y=360, control_name='LOGIN_ANIMATION_CENTER')
+                    center_click_count += 1
+                    logger.info(f'Login animation: clicked center area (attempt {center_click_count})')
+                    center_click_timer = Timer(3).start()
+                    self.screenshot()
+
+                if skip_click_timer.reached() and self.ocr_appear(self.O_LOGIN_ANIMATION_SKIP):
+                    x, y = self.O_LOGIN_ANIMATION_SKIP.coord()
+                    self.device.click(x=x, y=y, control_name=self.O_LOGIN_ANIMATION_SKIP.name)
+                    logger.info('Login animation: detected 跳过, clicked skip button')
+                    skip_click_timer = Timer(1).start()
+
+                    self.screenshot()
+                    if self.appear(self.I_LOGIN_8) or not self.ocr_appear(self.O_LOGIN_ANIMATION_SKIP):
+                        logger.info('Login animation: skip click confirmed')
+                    else:
+                        logger.warning('Login animation: skip click not confirmed, retrying')
                 continue
 
             if self.appear(self.I_EARLY_SERVER):

--- a/tasks/Restart/assets.py
+++ b/tasks/Restart/assets.py
@@ -110,9 +110,9 @@ class RestartAssets:
 	O_LOGIN_NETWORK = RuleOcr(roi=(534,649,189,39), area=(210,492,100,100), mode="Single", method="Default", keyword="正在连接服务器", name="login_network")
 	# Ocr-description 
 	O_LOGIN_ENTER_GAME = RuleOcr(roi=(550,567,176,56), area=(558,574,154,49), mode="Single", method="Default", keyword="进入游戏", name="login_enter_game")
-	# 点击屏幕跳过 
+	# 点击屏幕跳过
 	O_LOGIN_SKIP_1 = RuleOcr(roi=(1046,35,130,37), area=(1046,35,130,37), mode="Single", method="Default", keyword="点击屏幕跳过", name="login_skip_1")
+	# Redroid登录界面-跳过
+	O_LOGIN_REDROID_SKIP = RuleOcr(roi=(1110,35,100,45), area=(1135,40,70,35), mode="Single", method="Default", keyword="跳过", name="login_redroid_skip")
 	# 登录指定角色，默认第一个 
 	O_LOGIN_SPECIFIC_SERVE = RuleOcr(roi=(110,120,350,600), area=(110,120,350,600), mode="Full", method="Default", keyword="", name="login_specific_serve")
-
-

--- a/tasks/Restart/assets.py
+++ b/tasks/Restart/assets.py
@@ -112,7 +112,7 @@ class RestartAssets:
 	O_LOGIN_ENTER_GAME = RuleOcr(roi=(550,567,176,56), area=(558,574,154,49), mode="Single", method="Default", keyword="进入游戏", name="login_enter_game")
 	# 点击屏幕跳过
 	O_LOGIN_SKIP_1 = RuleOcr(roi=(1046,35,130,37), area=(1046,35,130,37), mode="Single", method="Default", keyword="点击屏幕跳过", name="login_skip_1")
-	# Redroid登录界面-跳过
-	O_LOGIN_REDROID_SKIP = RuleOcr(roi=(1110,35,100,45), area=(1135,40,70,35), mode="Single", method="Default", keyword="跳过", name="login_redroid_skip")
+	# 登录动画-跳过
+	O_LOGIN_ANIMATION_SKIP = RuleOcr(roi=(1110,35,100,45), area=(1135,40,70,35), mode="Single", method="Default", keyword="跳过", name="login_animation_skip")
 	# 登录指定角色，默认第一个 
 	O_LOGIN_SPECIFIC_SERVE = RuleOcr(roi=(110,120,350,600), area=(110,120,350,600), mode="Full", method="Default", keyword="", name="login_specific_serve")

--- a/tasks/Restart/assets.py
+++ b/tasks/Restart/assets.py
@@ -64,6 +64,8 @@ class RestartAssets:
 	C_LOGIN_ENSURE_LOGIN_CHARACTER_IN_SAME_SVR = RuleClick(roi_front=(600,240,500,400), roi_back=(600,240,500,400), name="login_ensure_login_character_in_same_svr")
 	# 卷轴关闭区域点击(用于点击I_LOGIN_SCROOLL_CLOSE的区域而不依赖图片识别) 
 	C_LOGIN_SCROLL_CLOSE_AREA = RuleClick(roi_front=(1181,634,28,39), roi_back=(1162,595,77,112), name="login_scroll_close_area")
+	# 登录动画点击屏幕中央区域
+	C_LOGIN_ANIMATION_CENTER = RuleClick(roi_front=(580,300,120,120), roi_back=(580,300,120,120), name="login_animation_center")
 
 
 	# Image Rule Assets

--- a/tasks/Restart/login/click.json
+++ b/tasks/Restart/login/click.json
@@ -10,5 +10,11 @@
     "roiFront": "1181,634,28,39",
     "roiBack": "1162,595,77,112",
     "description": "卷轴关闭区域点击(用于点击I_LOGIN_SCROOLL_CLOSE的区域而不依赖图片识别)"
+  },
+  {
+    "itemName": "login_animation_center",
+    "roiFront": "580,300,120,120",
+    "roiBack": "580,300,120,120",
+    "description": "登录动画点击屏幕中央区域"
   }
 ]

--- a/tasks/Restart/login/ocr.json
+++ b/tasks/Restart/login/ocr.json
@@ -27,6 +27,15 @@
     "description": "点击屏幕跳过"
   },
   {
+    "itemName": "login_redroid_skip",
+    "roiFront": "1110,35,100,45",
+    "roiBack": "1135,40,70,35",
+    "mode": "Single",
+    "method": "Default",
+    "keyword": "跳过",
+    "description": "Redroid登录界面-跳过"
+  },
+  {
     "itemName": "login_specific_serve",
     "roiFront": "110,120,350,600",
     "roiBack": "110,120,350,600",

--- a/tasks/Restart/login/ocr.json
+++ b/tasks/Restart/login/ocr.json
@@ -27,13 +27,13 @@
     "description": "点击屏幕跳过"
   },
   {
-    "itemName": "login_redroid_skip",
+    "itemName": "login_animation_skip",
     "roiFront": "1110,35,100,45",
     "roiBack": "1135,40,70,35",
     "mode": "Single",
     "method": "Default",
     "keyword": "跳过",
-    "description": "Redroid登录界面-跳过"
+    "description": "登录动画-跳过"
   },
   {
     "itemName": "login_specific_serve",

--- a/tasks/Restart/script_task.py
+++ b/tasks/Restart/script_task.py
@@ -42,26 +42,7 @@ class ScriptTask(BaseTask):
         self.device.app_start()
         self.device.wait_app_start_ready()
         login_service = LoginService(config=self.config, device=self.device)
-        if self.is_redroid():
-            login_service.prepare_redroid_login()
         login_service.app_handle_login()
-
-    def is_redroid(self) -> bool:
-        """判断当前设备是否为 Redroid，仅对 Redroid 执行特殊登录预处理。"""
-        try:
-            properties = (
-                self.device.adb_getprop('ro.hardware'),
-                self.device.adb_getprop('ro.product.name'),
-                self.device.adb_getprop('ro.product.model'),
-                self.device.adb_getprop('ro.build.fingerprint'),
-            )
-        except Exception as e:
-            logger.warning(f'Unable to detect Redroid environment: {e}')
-            return False
-
-        is_redroid = any('redroid' in value.lower() for value in properties)
-        logger.info(f'Redroid environment: {is_redroid}')
-        return is_redroid
 
     def app_restart(self):
         logger.hr('App restart')

--- a/tasks/Restart/script_task.py
+++ b/tasks/Restart/script_task.py
@@ -41,8 +41,7 @@ class ScriptTask(BaseTask):
         logger.hr('App start')
         self.device.app_start()
         self.device.wait_app_start_ready()
-        login_service = LoginService(config=self.config, device=self.device)
-        login_service.app_handle_login()
+        LoginService(config=self.config, device=self.device).app_handle_login()
 
     def app_restart(self):
         logger.hr('App restart')

--- a/tasks/Restart/script_task.py
+++ b/tasks/Restart/script_task.py
@@ -41,7 +41,27 @@ class ScriptTask(BaseTask):
         logger.hr('App start')
         self.device.app_start()
         self.device.wait_app_start_ready()
-        LoginService(config=self.config, device=self.device).app_handle_login()
+        login_service = LoginService(config=self.config, device=self.device)
+        if self.is_redroid():
+            login_service.prepare_redroid_login()
+        login_service.app_handle_login()
+
+    def is_redroid(self) -> bool:
+        """判断当前设备是否为 Redroid，仅对 Redroid 执行特殊登录预处理。"""
+        try:
+            properties = (
+                self.device.adb_getprop('ro.hardware'),
+                self.device.adb_getprop('ro.product.name'),
+                self.device.adb_getprop('ro.product.model'),
+                self.device.adb_getprop('ro.build.fingerprint'),
+            )
+        except Exception as e:
+            logger.warning(f'Unable to detect Redroid environment: {e}')
+            return False
+
+        is_redroid = any('redroid' in value.lower() for value in properties)
+        logger.info(f'Redroid environment: {is_redroid}')
+        return is_redroid
 
     def app_restart(self):
         logger.hr('App restart')


### PR DESCRIPTION
- 仅在检测到 Redroid 容器设备时启用特殊登录流程，普通设备保持原有行为。

- 启动阴阳师并确认画面准备完成后，额外等待 3 秒再首次点击屏幕中心。

- 通过 OCR 识别 Redroid 容器登录画面右上角的完整“跳过”按钮，并使用收紧后的识别区域和点击区域，避免点击到按钮外。

- OCR 未及时识别到按钮时，每 3 秒重试一次中心点击；总等待 30 秒后回退到原有登录流程。

- 保留原有“点击屏幕跳过”规则，不影响非 Redroid 容器设备的登录逻辑。

<img width="1280" height="720" alt="current_adb_screen" src="https://github.com/user-attachments/assets/85c1393f-2ae8-4faf-8753-a15800648599" />
因为redroid容器跑阴阳师就算设置里面勾选了关闭动画，但是阴阳师这里还是会播放动画，而且oas群里面也有几个用ubuntu配着redroid容器的都出现了这种情况，所以提个pr。（Codex写的，麻烦路飞佬看看有没有什么问题）