### PR TITLE
增加登录动画中央点击次数

### DIFF
--- a/tasks/Component/Login/service.py
+++ b/tasks/Component/Login/service.py
@@ -28,7 +28,7 @@ class LoginService(BaseTask, RestartAssets, GameUiAssets):
         confirm_timer = Timer(1.5, count=2).start()
         orientation_timer = Timer(10)
         skip_login_animation = True
-        skip_click_mx_cnt = 3
+        skip_click_mx_cnt = 10
         login_success = False
 
         while 1:


### PR DESCRIPTION
原先的3次太少了一点，全都点在了加载页面，然后oas就开始识别“跳过”“进入游戏”那些，但游戏还处于动画页面所以ocr识别不到会超时报错。增加了点次数就没问题了（10次可能多了点，但考虑到redroid和设备性能导致加载慢所以就设置充足了点）
<img width="720" height="360" alt="e62e86aab70eb87f95cef82cb4d0c3c0" src="https://github.com/user-attachments/assets/12031d9e-2bdd-4381-9739-8c5428549750" />
