### PR TITLE
fix(BondlingFairyland): 修复单刷过场时识别过快判定战斗失败的情况

### DIFF
--- a/tasks/BondlingFairyland/script_task.py
+++ b/tasks/BondlingFairyland/script_task.py
@@ -618,6 +618,7 @@ class ScriptTask(GameUi, GeneralInvite, GeneralRoom, GeneralBattle, SwitchSoul, 
         while 1:
             self.screenshot()
             if not self.appear(self.I_BALL_FIRE, threshold=0.7):
+                sleep(1)
                 return True
             # 盘子少于10个停止,略过具体数量防止ocr识别错误导致退出
             if self.appear_then_click(self.I_C_PLATE_LESS, interval=1):


### PR DESCRIPTION
-修复单刷过场时识别过快判定战斗失败的情况，添加1s间隔