### PR TITLE
fix(BondlingFairyland): 修复契灵建房过渡期间ensure_private空转导致的卡死

### DIFF
--- a/tasks/BondlingFairyland/script_task.py
+++ b/tasks/BondlingFairyland/script_task.py
@@ -156,7 +156,7 @@ class ScriptTask(GameUi, GeneralInvite, GeneralRoom, GeneralBattle, SwitchSoul, 
                     if self.appear_then_click(self.I_UI_CONFIRM, interval=1):
                         continue
                     if self.appear(self.I_CREATE_TEAM, interval=1):
-                        self.ensure_private()
+                        self.ensure_private(room_mark=self.I_GI_IN_ROOM)
                         self.appear_then_click(self.I_CREATE_TEAM, interval=2)
                         continue
                     # 求援

--- a/tasks/Component/GeneralRoom/general_room.py
+++ b/tasks/Component/GeneralRoom/general_room.py
@@ -42,9 +42,17 @@ class GeneralRoom(BaseTask, GeneralRoomAssets):
                 return True
         return False
 
-    def ensure_private(self) -> bool:
+    def ensure_private(self, room_mark: RuleImage = None) -> bool:
         """
         确认私人房间, 不公开仅邀请
+
+        正常情况下弹窗上的"不公开(仅邀请)"开关匹配到即返回。
+        但存在建房过渡动画期间(弹窗已关闭、房间已建成)本方法仍被调用的时序,
+        此时四个弹窗资产全部匹配不到会空转直至卡死检测。传入 room_mark 后,
+        若检测到房间已建成则视为私人设置已生效, 直接返回, 避免空转。
+
+        :param room_mark: 可选。房间已建成界面的特征图(如房间标题栏/协战队伍)。
+                          为 None 时行为与旧版完全一致。
         :return:
         """
         logger.info('Ensure private')
@@ -58,6 +66,10 @@ class GeneralRoom(BaseTask, GeneralRoomAssets):
                 continue
             if self.appear_then_click(self.I_ENSURE_PRIVATE_FALSE_2, interval=1):
                 continue
+            # 弹窗上的开关匹配不到但房间已经建成: 私人设置此前已生效(或沿用上次设置), 直接放行
+            if room_mark is not None and self.appear(room_mark):
+                logger.info('Room already created, private ensured')
+                return True
         return False
 
     def ensure_public(self) -> bool:


### PR DESCRIPTION
不知道是不是nemu截图速度太快了才会这样，在我这出现概率非常高
```log
2026-09-08 10:14:56.311 |            logger.py:0471 |     INFO | [B_BALL_NUMBER 0.008s] [93/99]                                                                 
2026-09-08 10:14:56.314 |       script_task.py:0167 |     INFO | ball is cu 93, total 99                                                                        
2026-09-08 10:14:56.466 |           control.py:0078 |     INFO | [0.15s] Click ( 982,  631) @ BALL_BALL_HELP                                                    
2026-09-08 10:14:57.525 |      general_room.py:0050 |     INFO | Ensure private                                                                                 
2026-09-08 10:14:57.989 |           control.py:0078 |     INFO | [0.17s] Click ( 611,  519) @ BALL_CREATE_TEAM                                                  
2026-09-08 10:14:58.132 |      general_room.py:0050 |     INFO | Ensure private                                                                                 
2026-09-08 10:15:57.968 |            device.py:0185 |  WARNING | Wait too long                                                                                  
2026-09-08 10:15:57.971 |            device.py:0186 |  WARNING | Waiting for set()
```
