### PR TITLE
fix(BondlingFairyland): 契灵房间锁定后跳过准备页点击, 避免误点右侧式神

### DIFF
--- a/tasks/BondlingFairyland/script_task.py
+++ b/tasks/BondlingFairyland/script_task.py
@@ -74,6 +74,20 @@ class ScriptTask(GameUi, GeneralInvite, GeneralRoom, GeneralBattle, SwitchSoul, 
         context.is_win = is_win
         return ret
 
+    def click_fire(self):
+        # 队友进房后、点开始挑战前, 采样房间锁定状态(契灵锁定后系统会自动开战)
+        self.screenshot()
+        self._room_locked = self.is_in_room(False) and \
+            bool(self.appear(self.I_LOCK)) and not bool(self.appear(self.I_UNLOCK))
+        logger.info(f'Bondling room locked: {self._room_locked}')
+        return super().click_fire()
+
+    def _prepare_click_ready(self, context: BattleContext, config: GeneralBattleConfig) -> bool:
+        # 已锁定则跳过准备按钮点击(避免误匹配点到右侧式神), 等系统自动开战
+        if getattr(self, '_room_locked', False):
+            return False
+        return super()._prepare_click_ready(context, config)
+
     def run(self):
         cong = self.config.bondling_fairyland
 
@@ -274,6 +288,9 @@ class ScriptTask(GameUi, GeneralInvite, GeneralRoom, GeneralBattle, SwitchSoul, 
 
             if self.is_in_room(False):
                 logger.info("契灵：已经在组队房间中")
+                # 开战前采样锁定状态(锁定后全员自动准备, 准备页可跳过点击)
+                self._room_locked = bool(self.appear(self.I_LOCK)) and not bool(self.appear(self.I_UNLOCK))
+                logger.info(f'Bondling room locked: {self._room_locked}')
                 if self.wait_battle(wait_time=self.config.bondling_fairyland.invite_config.wait_time):
                     self.run_general_battle(self.config.bondling_fairyland.battle_config)
                     wait_timer.reset()


### PR DESCRIPTION
契灵组队阵容锁定后系统会自动准备开战, 但脚本在准备页仍会每帧点击
"准备"按钮。低帧率或动画过渡时 I_PREPARE_HIGHLIGHT 模板误匹配到
右侧式神, 点击落到式神上导致绿标指向错误目标而战败。

- override click_fire(): 点开始挑战前(队友已进房)用房间锁图标采样锁定 状态, I_LOCK 命中且 I_UNLOCK 未命中才视为已锁定
- override _prepare_click_ready(): 已锁定则跳过准备按钮点击, 等待 系统自动开战, 否则回落原逻辑
- run_member 队员进房等待时同步采样一次, 队长锁定后队员同样受益
- 未锁定/识别不到锁图标时保守按未锁定处理, 行为与原版一致; 仅契灵任务受影响, 通用组件与其他任务零改动

Closes #273